### PR TITLE
Add lflags exceptions for exclusiveMerge

### DIFF
--- a/source/redub/buildapi.d
+++ b/source/redub/buildapi.d
@@ -500,7 +500,7 @@ private auto save(TRange)(TRange input)
 */
 ref string[] exclusiveMerge(StringRange)(return scope ref string[] a, StringRange b, scope const string[] excludeFromMerge = null)
 {
-    import std.algorithm.searching:countUntil;
+    import std.algorithm.searching : countUntil;
     import std.array;
     auto app = appender!(string[]);
     scope(exit)
@@ -511,7 +511,7 @@ ref string[] exclusiveMerge(StringRange)(return scope ref string[] a, StringRang
     {
         if(bV.length == 0) continue;
         if(countUntil(excludeFromMerge, bV) != -1) continue;
-        foreach(aV; a)
+        else foreach(aV; a)
         {
             if(aV == bV)
                 continue outer;

--- a/source/redub/parsers/base.d
+++ b/source/redub/parsers/base.d
@@ -138,7 +138,7 @@ void addFrameworks(ref BuildRequirements req, JSONStringArray frameworks, ParseC
 }
 void addVersions(ref BuildRequirements req, JSONStringArray vers, ParseConfig c){req.cfg.versions.exclusiveMerge(vers);}
 void addDebugVersions(ref BuildRequirements req, JSONStringArray vers, ParseConfig c){req.cfg.debugVersions.exclusiveMerge(vers);}
-void addLinkFlags(ref BuildRequirements req, JSONStringArray lFlags, ParseConfig c){req.cfg.linkFlags.exclusiveMerge(lFlags);}
+void addLinkFlags(ref BuildRequirements req, JSONStringArray lFlags, ParseConfig c){req.cfg.linkFlags.exclusiveMerge(lFlags, linkerMergeExceptions);}
 void addDflags(ref BuildRequirements req, JSONStringArray dFlags, ParseConfig c){req.cfg.dFlags.exclusiveMerge(dFlags);}
 void addDependency(
     ref BuildRequirements req, 
@@ -214,3 +214,10 @@ void addSubConfiguration(
     else
         req.dependencies[depIndex].subConfiguration = BuildRequirements.Configuration(subConfigurationName, false);
 }
+
+const string[] linkerMergeExceptions = [
+    "-l",
+    "-framework",
+    "-L",
+    "/LIBPATH",
+];


### PR DESCRIPTION
Some lflags being passed should never get exclusively merged, this adds a list of exceptions that can be expanded later.