### PR TITLE
Speed-up when VT100 escape codes are enabled on the console

### DIFF
--- a/colorize/source/redub/libs/colorize/cwrite.d
+++ b/colorize/source/redub/libs/colorize/cwrite.d
@@ -47,6 +47,12 @@ void cwrite(S...)(File f, S args)
 	{
 		WinTermEmulation winterm;
 		winterm.initialize();
+		if (winterm.supportVT100)
+		{
+			f.write(s);
+			return;
+		}
+
 		foreach(dchar c ; s)
 		{
 			auto charAction = winterm.feed(c);

--- a/colorize/source/redub/libs/colorize/winterm.d
+++ b/colorize/source/redub/libs/colorize/winterm.d
@@ -19,12 +19,17 @@ version(Windows)
 	struct WinTermEmulation
 	{
 		public:
-			@nogc void initialize() nothrow
+			bool supportVT100; // if true, that whole emulation is useless.
+
+			void initialize() nothrow
 			{
 				// saves console attributes
 				_console = GetStdHandle(STD_OUTPUT_HANDLE);
 				_savedInitialColor = (0 != GetConsoleScreenBufferInfo(_console, &consoleInfo));
 				_state = State.initial;
+				uint mode;
+				if (GetConsoleMode(_console, &mode))
+					supportVT100 = (mode & ENABLE_VIRTUAL_TERMINAL_INPUT) != 0;
 			}
 
 			@nogc ~this() nothrow


### PR DESCRIPTION
Basically Windows stdout is faster, and this avoids some lagging in redub.