### PR TITLE
Stop refusing to build on freebsd

### DIFF
--- a/source/redub/plugin/load.d
+++ b/source/redub/plugin/load.d
@@ -173,6 +173,8 @@ string getDynamicLibraryName(string dynamicLibPath)
         return buildNormalizedPath(dir, name~".dll");
     else version(linux)
         return buildNormalizedPath(dir, "lib"~name~".so");
+    else version(FreeBSD)
+        return buildNormalizedPath(dir, "lib"~name~".so");
     else version(OSX)
         return buildNormalizedPath(dir, "lib"~name~".dylib");
     else static assert(false, "No support for dynamic libraries on that OS.");


### PR DESCRIPTION
Pretty simple change to `getDynamicLibraryName()` which static asserts an error for any OS that isn't  windows, linux, or OSX. With this change, it only static asserts an error for any OS that isn't windows, linux, FreeBSD, or OSX